### PR TITLE
Remove title from user controller...

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   extends: ['./node_modules/poetic/config/eslint/eslint-config.js'],
   // Add custom rules here
   rules: {
+    camelcase: 'off',
     'arrow-parens': 'off',
     quotes: 'off',
     'no-unexpected-multiline': 'off',
@@ -10,7 +11,7 @@ module.exports = {
     'react/prefer-stateless-function': 'warn',
     'react/prop-types': 'warn',
     'import/prefer-default-export': 'off',
-    '@typescript-eslint/camelcase': 'warn',
+    '@typescript-eslint/camelcase': 'off',
     'func-names': 'off',
     '@typescript-eslint/no-var-requires': 'off',
     'no-restricted-globals': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,6 @@ module.exports = {
   extends: ['./node_modules/poetic/config/eslint/eslint-config.js'],
   // Add custom rules here
   rules: {
-    camelcase: 'off',
     'arrow-parens': 'off',
     quotes: 'off',
     'no-unexpected-multiline': 'off',
@@ -11,7 +10,7 @@ module.exports = {
     'react/prefer-stateless-function': 'warn',
     'react/prop-types': 'warn',
     'import/prefer-default-export': 'off',
-    '@typescript-eslint/camelcase': 'off',
+    '@typescript-eslint/camelcase': 'warn',
     'func-names': 'off',
     '@typescript-eslint/no-var-requires': 'off',
     'no-restricted-globals': 'off',

--- a/src/server/api/controllers/users.controller.js
+++ b/src/server/api/controllers/users.controller.js
@@ -5,26 +5,16 @@ const knex = require('../../config/db');
 const Error = require('../lib/utils/http-error');
 const moment = require('moment-timezone');
 
-const getUsers = async () => {
-  try {
-    return await knex('users').select('users.id', 'users.title');
-  } catch (error) {
-    return error.message;
-  }
-};
+const getUsers = () => knex('users').select('*');
 
 const getUsersById = async (id) => {
-  try {
-    const users = await knex('users')
-      .select('users.id as id', 'title')
-      .where({ id });
-    if (users.length === 0) {
-      throw new Error(`incorrect entry with the id of ${id}`, 404);
-    }
-    return users;
-  } catch (error) {
-    return error.message;
+  const users = await knex('users')
+    .select('*')
+    .where({ id });
+  if (users.length !== 1) {
+    throw new Error(`incorrect entry with the id of ${id}`, 404);
   }
+  return users[0];
 };
 
 const editUser = async (userId, updatedUser) => {
@@ -47,7 +37,7 @@ const deleteUser = async (usersId) => {
 
 const createUser = async (body) => {
   await knex('users').insert({
-    title: body.title,
+    full_name: body.full_name,
     startDate: moment(body.startDate).format(),
     endDate: moment(body.endDate).format(),
     classId: body.classId,


### PR DESCRIPTION
... and return single result.

# Description

Fixes # (issue)

Remove 'title' throughout users.controller.js as the column doesn't exist in our table users.
Fix the return value from `getUsers ` to get all the info from a user and not just an id.

# How to test?

Please provide a short summary how your changes can be tested?

npm run db:setup
npm run dev
http://localhost:3000/api/users
![Screenshot (2362)](https://user-images.githubusercontent.com/36211640/105170508-4bdebd80-5b1d-11eb-8e5d-4d61f89caea9.png)

http://localhost:3000/api/users/2
![Screenshot (2363)](https://user-images.githubusercontent.com/36211640/105170522-5436f880-5b1d-11eb-8c90-3d31a5207f54.png)


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] This PR is ready to be merged and not breaking any other functionality
