### PR TITLE
updated drop_column to drop_foriegn in down migration

### DIFF
--- a/src/server/migrations/20210121233615_update_cvs_migration.js
+++ b/src/server/migrations/20210121233615_update_cvs_migration.js
@@ -19,7 +19,7 @@ exports.down = function(knex) {
   return knex.schema.table('cvs', (table) => {
     table.dropColumn('description');
     table.dropColumn('file_url');
-    table.dropColumn('fk_user_id');
+    table.dropForeign('fk_user_id');
     table.dropColumn('fk_user_id');
     table.dropColumn('updatedAt');
     table.dropColumn('deletedAt');


### PR DESCRIPTION
# Description

This PR is to correct the drop migration function in cvs table. 

Fixes # 57

# How to test?

run npm run db:clean  and npm run db:setup and the migration and seeds should run

# Checklist

- [x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [x ] This PR is ready to be merged and not breaking any other functionality
