### PR TITLE
Endpoint to delete CVs using the parameter ID

### DIFF
--- a/src/server/api/controllers/cvs.controller.js
+++ b/src/server/api/controllers/cvs.controller.js
@@ -7,14 +7,10 @@ const moment = require('moment-timezone');
 const getCvs = async (title, limit) => {
   try {
     if (title) {
-      return await knex('cvs')
-        .select('*')
-        .where('title', 'like', `%${title}%`);
+      return await knex('cvs').select('*').where('title', 'like', `%${title}%`);
     }
     if (limit) {
-      return await knex('cvs')
-        .select('*')
-        .limit({ limit });
+      return await knex('cvs').select('*').limit({ limit });
     }
     return await knex('cvs')
       .select('*')
@@ -27,9 +23,7 @@ const getCvs = async (title, limit) => {
 
 const getCvById = async (id) => {
   try {
-    const cvs = await knex('cvs')
-      .select('cvs.id as id', 'title')
-      .where({ id });
+    const cvs = await knex('cvs').select('cvs.id as id', 'title').where({ id });
     if (cvs.length === 0) {
       throw new Error(`incorrect entry with the id of ${id}`, 404);
     }
@@ -48,10 +42,8 @@ const editCv = async (cvId, updatedCv) => {
     });
 };
 
-const deleteCv = async (cvId) => {
-  return knex('cv')
-    .where({ id: cvId })
-    .del();
+const deleteCv = async (cvsId) => {
+  return knex('cvs').where({ id: cvsId }).del();
 };
 
 const createCv = async (body) => {

--- a/src/server/api/routes/cvs.router.js
+++ b/src/server/api/routes/cvs.router.js
@@ -92,10 +92,7 @@ router.post('/', (req, res) => {
     .catch((error) => {
       console.log(error);
 
-      res
-        .status(400)
-        .send('Bad request')
-        .end();
+      res.status(400).send('Bad request').end();
     });
 });
 
@@ -147,13 +144,13 @@ router.patch('/:id', (req, res, next) => {
  *        description: ID of the cv to delete.
  *    responses:
  *      200:
- *        description:  CV deleted
+ *        description:  CV is deleted
  *      5XX:
  *        description: Unexpected error.
  */
 router.delete('/:id', (req, res) => {
   cvsController
-    .deleteModule(req.params.id, req)
+    .deleteCv(req.params.id, req)
     .then((result) => {
       // If result is equal to 0, then that means the cv id does not exist
       if (result === 0) {


### PR DESCRIPTION
# Description
This is the Endpoint from where you can delete Cvs using ID parameter

Fixes https://github.com/HackYourFuture-CPH/rate-my-cv/issues/3

# How to test?
On postman, i have tested it and results are as below;
<img width="613" alt="delete_cv_byId" src="https://user-images.githubusercontent.com/58881390/106643639-4b690c80-658a-11eb-8847-5db06e54f1c3.PNG">

# Checklist

- [*] I have performed a self-review of my own code
- [*] I have commented my code, particularly in hard-to-understand areas
- [*] I have made corresponding changes to the documentation
- [*] This PR is ready to be merged and not breaking any other functionality
