### PR TITLE
Endpoint_to_delete_CVs_using parameter_ID

### DIFF
--- a/src/server/api/controllers/cvs.controller.js
+++ b/src/server/api/controllers/cvs.controller.js
@@ -42,7 +42,7 @@ const editCv = async (cvId, updatedCv) => {
     });
 };
 
-const deleteCv = async (cvsId) => {
+const deleteCvs = async (cvsId) => {
   return knex('cvs').where({ id: cvsId }).del();
 };
 
@@ -60,7 +60,7 @@ const createCv = async (body) => {
 module.exports = {
   getCvs,
   getCvById,
-  deleteCv,
+  deleteCvs,
   createCv,
   editCv,
 };

--- a/src/server/api/controllers/cvs.controller.js
+++ b/src/server/api/controllers/cvs.controller.js
@@ -7,14 +7,10 @@ const moment = require('moment-timezone');
 const getCvs = async (title, limit) => {
   try {
     if (title) {
-      return await knex('cvs')
-        .select('*')
-        .where('title', 'like', `%${title}%`);
+      return await knex('cvs').select('*').where('title', 'like', `%${title}%`);
     }
     if (limit) {
-      return await knex('cvs')
-        .select('*')
-        .limit({ limit });
+      return await knex('cvs').select('*').limit({ limit });
     }
     return await knex('cvs')
       .select('*')
@@ -27,9 +23,7 @@ const getCvs = async (title, limit) => {
 
 const getCvById = async (id) => {
   try {
-    const cvs = await knex('cvs')
-      .select('cvs.id as id', 'title')
-      .where({ id });
+    const cvs = await knex('cvs').select('cvs.id as id', 'title').where({ id });
     if (cvs.length === 0) {
       throw new Error(`incorrect entry with the id of ${id}`, 404);
     }
@@ -48,10 +42,8 @@ const editCv = async (cvId, updatedCv) => {
     });
 };
 
-const deleteCv = async (cvId) => {
-  return knex('cv')
-    .where({ id: cvId })
-    .del();
+const deleteCv = async (cvsId) => {
+  return knex('cvs').where({ id: cvsId }).del();
 };
 
 const createCv = async (body) => {

--- a/src/server/api/routes/cvs.router.js
+++ b/src/server/api/routes/cvs.router.js
@@ -92,10 +92,7 @@ router.post('/', (req, res) => {
     .catch((error) => {
       console.log(error);
 
-      res
-        .status(400)
-        .send('Bad request')
-        .end();
+      res.status(400).send('Bad request').end();
     });
 });
 
@@ -137,23 +134,23 @@ router.patch('/:id', (req, res, next) => {
  * @swagger
  * /cvs/{ID}:
  *  delete:
- *    summary: Delete a cv
+ *    summary: Delete a certain CV
  *    description:
- *      Will delete a cv with a given ID.
+ *      Will delete a CV with a given ID.
  *    produces: application/json
  *    parameters:
  *      - in: path
  *        name: ID
- *        description: ID of the cv to delete.
+ *        description: ID of the CV to be deleted.
  *    responses:
  *      200:
- *        description:  CV deleted
+ *        description:  CV is finally deleted
  *      5XX:
  *        description: Unexpected error.
  */
 router.delete('/:id', (req, res) => {
   cvsController
-    .deleteModule(req.params.id, req)
+    .deleteCv(req.params.id, req)
     .then((result) => {
       // If result is equal to 0, then that means the cv id does not exist
       if (result === 0) {

--- a/src/server/api/routes/cvs.router.js
+++ b/src/server/api/routes/cvs.router.js
@@ -150,7 +150,7 @@ router.patch('/:id', (req, res, next) => {
  */
 router.delete('/:id', (req, res) => {
   cvsController
-    .deleteCv(req.params.id, req)
+    .deleteCvs(req.params.id, req)
     .then((result) => {
       // If result is equal to 0, then that means the cv id does not exist
       if (result === 0) {


### PR DESCRIPTION
# Title: Endpoint_to_delete_CVs_using parameter_ID. 

Fixes https://github.com/HackYourFuture-CPH/rate-my-cv/issues/3

# How to test? You can test it on POSTMAN,.,. I have gotten below results; 1 CV was deleted as it has a certain ID

<img width="621" alt="CV_deleted" src="https://user-images.githubusercontent.com/58881390/106830766-fd89fc80-668e-11eb-8a39-1b589a32d947.PNG">

Another CV wasn't deleted as it's ID don't exist.
<img width="647" alt="CV_2b_deleted, dont exists" src="https://user-images.githubusercontent.com/58881390/106830775-024eb080-668f-11eb-8bd4-5f1200132fb0.PNG">

# Checklist

- [*] I have performed a self-review of my own code
- [*] I have commented my code, particularly in hard-to-understand areas
- [*] I have made corresponding changes to the documentation
- [*] This PR is ready to be merged and not breaking any other functionality
