### PR TITLE
endpoint_to_delete_cv_using_parameter_ID

### DIFF
--- a/src/server/api/controllers/cvs.controller.js
+++ b/src/server/api/controllers/cvs.controller.js
@@ -48,8 +48,8 @@ const editCv = async (cvId, updatedCv) => {
     });
 };
 
-const deleteCv = async (cvId) => {
-  return knex('cv')
+const deleteCvs = async (cvId) => {
+  return knex('cvs')
     .where({ id: cvId })
     .del();
 };
@@ -68,7 +68,7 @@ const createCv = async (body) => {
 module.exports = {
   getCvs,
   getCvById,
-  deleteCv,
+  deleteCvs,
   createCv,
   editCv,
 };

--- a/src/server/api/routes/cvs.router.js
+++ b/src/server/api/routes/cvs.router.js
@@ -136,24 +136,24 @@ router.patch('/:id', (req, res, next) => {
 /**
  * @swagger
  * /cvs/{ID}:
- *  delete:
- *    summary: Delete a cv
+ *  Delete:
+ *    summary: Delete a certain CV.
  *    description:
  *      Will delete a cv with a given ID.
  *    produces: application/json
  *    parameters:
  *      - in: path
  *        name: ID
- *        description: ID of the cv to delete.
+ *        description: ID of the CV to be deleted.
  *    responses:
  *      200:
- *        description:  CV deleted
+ *        description:  CV is finally deleted
  *      5XX:
  *        description: Unexpected error.
  */
 router.delete('/:id', (req, res) => {
   cvsController
-    .deleteModule(req.params.id, req)
+    .deleteCvs(req.params.id, req)
     .then((result) => {
       // If result is equal to 0, then that means the cv id does not exist
       if (result === 0) {


### PR DESCRIPTION
# Description
endpoint_to_delete_cv_using_parameter_ID



Fixes #3 

# How to test?
ON Postman, when you try to delete a cv whichs ID doesn't exist,.,.it says as below;
<img width="639" alt="CV_to_deleted_doesn't_exist" src="https://user-images.githubusercontent.com/58881390/107143723-f8e77180-6936-11eb-95b0-e05e689e7392.PNG">

If you try to delete an existing CV,.,it reports as below;

<img width="613" alt="delete_cv_byId" src="https://user-images.githubusercontent.com/58881390/107143752-19afc700-6937-11eb-9310-9e3e7119933f.PNG">


# Checklist

- [*] I have performed a self-review of my own code
- [*] I have commented my code, particularly in hard-to-understand areas
- [*] I have made corresponding changes to the documentation
- [*] This PR is ready to be merged and not breaking any other functionality
