### PR TITLE
Remove width property in component...

### DIFF
--- a/src/client/components/ProfileCardComponent/ProfileCardComponent.styles.css
+++ b/src/client/components/ProfileCardComponent/ProfileCardComponent.styles.css
@@ -1,7 +1,6 @@
 .profile-card-whole {
   box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.05);
   border-radius: 15px;
-  width: 30%;
   justify-content: center;
 }
 
@@ -80,8 +79,5 @@ hr {
   .circle {
     max-width: 100px;
     max-height: 100px;
-  }
-  .profile-card-whole {
-    width: 70%;
   }
 }


### PR DESCRIPTION
... to allow it to scale properly when used with other components

# Description

Removed the width property for the component so it takes the whole width of the container that holds it, so when used in other pages it scales properly.

Fixes # (issue)

When working on the issue #143 we realized that the width was wrong as the component was taking a width of 30% of it's container.

# How to test?

Run storybook:

All the components should take the width of the screen, as shown in the picture:

![Screenshot (2567)](https://user-images.githubusercontent.com/36211640/108556813-e63a4880-72f7-11eb-9051-392f1663a0b2.png)
 

Please provide a short summary how your changes can be tested?

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] This PR is ready to be merged and not breaking any other functionality
