### PR TITLE
Fix console errors from missing keys and ...

### DIFF
--- a/src/client/components/MyProfile/YourUploadedCVs/YourUploadedCVs.js
+++ b/src/client/components/MyProfile/YourUploadedCVs/YourUploadedCVs.js
@@ -23,8 +23,8 @@ export function YourUploadedCVs({ CVsList }) {
       <ul>
         {CVsList.map((cv, i) => {
           return i < 3 ? (
-            <li>
-              <CVList title={cv.title} date={cv.created_date} />
+            <li key={cv.id}>
+              <CVList title={cv.title} date={cv.createdDate.toLocaleString()} />
               <RatingStars averageStars={(cv.averageStars * 100) / 5} />
               <div className="download">
                 <Button
@@ -48,6 +48,13 @@ export function YourUploadedCVs({ CVsList }) {
   );
 }
 
+const Cvs = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  title: PropTypes.string.isRequired,
+  createdDate: PropTypes.instanceOf(Date).isRequired,
+  averageStars: PropTypes.number.isRequired,
+});
+
 YourUploadedCVs.propTypes = {
-  CVsList: PropTypes.string.isRequired,
+  CVsList: PropTypes.arrayOf(Cvs).isRequired,
 };

--- a/src/client/components/MyProfile/YourUploadedCVs/YourUploadedCVs.stories.js
+++ b/src/client/components/MyProfile/YourUploadedCVs/YourUploadedCVs.stories.js
@@ -12,25 +12,25 @@ export const YourUploadedCV = () => (
       {
         id: 3,
         title: 'Mechanical Engineer',
-        created_date: '2020-10-20',
+        createdDate: new Date('2020-10-20'),
         averageStars: 4.5,
       },
       {
         id: 5,
         title: 'Technical Auditor',
-        created_date: '2021-01-21',
+        createdDate: new Date('2021-01-21'),
         averageStars: 3.4,
       },
       {
         id: 9,
         title: 'ghofranebenhamid-vc-v3',
-        created_date: '2021-03-21',
+        createdDate: new Date('2021-03-21'),
         averageStars: 4,
       },
       {
         id: 10,
         title: 'React Programmer',
-        created_date: '2021-03-25',
+        createdDate: new Date('2021-03-25'),
         averageStars: 2.4,
       },
     ]}


### PR DESCRIPTION
type of the cvs, fix type of date and correct name of variable due to a linter warning

# Description

Fix console errors from missing keys and type of Cvs. Additionally, the type of the date is set from string to date and change name of a variable due to linting warnings.

Fixes # (issue)
These two errors will be removed
![Screenshot (2593)_LI](https://user-images.githubusercontent.com/36211640/108710249-16f6c980-7514-11eb-96f2-2afda8116805.jpg)

# How to test?

Run storybook, the errors shown with a blue arrow should be gone

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] This PR is ready to be merged and not breaking any other functionality
