### PR TITLE
the functionality to reload profile after adding resume

### DIFF
--- a/src/client/components/AddResume/AddResume.js
+++ b/src/client/components/AddResume/AddResume.js
@@ -1,20 +1,26 @@
 import React, { useState } from 'react';
 import ReactDom from 'react-dom';
-import {useHistory} from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import Button from '../Button/Button';
 import './AddResume.css';
 import close from '../../assets/images/closeIcon.svg';
 import { useStorage } from '../../hooks/fileUploader';
 import { useAuthentication } from '../../hooks/useAuthentication';
 
-export const AddResume = ({isShown,setIsShown}) => {
+export const AddResume = ({ isShown, setIsShown, setIsLoaded }) => {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [error, setError] = useState(null);
-  const { uploadedFile, setUploadedFile, uploadFile, uploadToStorage, url } = useStorage();
+  const {
+    uploadedFile,
+    setUploadedFile,
+    uploadFile,
+    uploadToStorage,
+    url,
+  } = useStorage();
   const { userData } = useAuthentication();
   const history = useHistory();
-  
+
   const types = [
     'application/pdf',
     'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
@@ -37,90 +43,94 @@ export const AddResume = ({isShown,setIsShown}) => {
       }
     }
   };
-  
+
   const clickHandler = () => {
-      uploadFile(title, description, userData.id, url);
-      history.push('/profile');
+    history.push('/profile');
+    setIsShown(false);
+    setIsLoaded(false);
+    uploadFile(title, description, userData.id, url);
   };
 
-  return ReactDom.createPortal(isShown ? (
-    <div className="modal">
-      <div className="modal-form">
-        <div className="close-icon"
-          onClick={() => setIsShown(false)}
-          onKeyPress={() =>setIsShown(false)}
-          draggable={false}
-          role="button"
-          tabIndex="0"
-        >
-        <img src={close} alt="close Icon" />
-        </div>
-        <h3 className="text">Upload new CV</h3>
-        <div className="uploadform">
-          <div className="title">
-            <label>Add Title</label>
-            <div>
-              <input
-                type="text"
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-              />
-            </div>
+  return ReactDom.createPortal(
+    isShown ? (
+      <div className="modal">
+        <div className="modal-form">
+          <div
+            className="close-icon"
+            onClick={() => setIsShown(false)}
+            onKeyPress={() => setIsShown(false)}
+            draggable={false}
+            role="button"
+            tabIndex="0"
+          >
+            <img src={close} alt="close Icon" />
           </div>
-          <div className="description">
-            <label>Description</label>
-            <div>
-              <textarea
-                type="text"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-              />
+          <h3 className="text">Upload new CV</h3>
+          <div className="uploadform">
+            <div className="title">
+              <label>Add Title</label>
+              <div>
+                <input
+                  type="text"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                />
+              </div>
             </div>
-          </div>
-          <div className="upload">
-            <label>
-              Select a file
-              <span className="support-text">
-                * File supported DOC,DOCX,PDF,RTF,TXT, 5MB Max
-              </span>
-            </label>
-            <form id="file-chosen">
-              <input
-                type="file"
-                id="file-grabber"
-                onChange={handleChange}
-                hidden
-              />
-              <label htmlFor="file-grabber" className="browse-button">
-                Browse
+            <div className="description">
+              <label>Description</label>
+              <div>
+                <textarea
+                  type="text"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                />
+              </div>
+            </div>
+            <div className="upload">
+              <label>
+                Select a file
+                <span className="support-text">
+                  * File supported DOC,DOCX,PDF,RTF,TXT, 5MB Max
+                </span>
               </label>
-              <span>{uploadedFile ? uploadedFile.name : ''}</span>
-            </form>
+              <form id="file-chosen">
+                <input
+                  type="file"
+                  id="file-grabber"
+                  onChange={handleChange}
+                  hidden
+                />
+                <label htmlFor="file-grabber" className="browse-button">
+                  Browse
+                </label>
+                <span>{uploadedFile ? uploadedFile.name : ''}</span>
+              </form>
+            </div>
           </div>
-        </div>
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'row',
-            float: 'right',
-          }}
-        >
-          {error && (
-            <p style={{ color: 'red', marginRight: '50px' }}>{error}</p>
-          )}
-          {uploadedFile ? (
-            <div className="add-btn">
-              <Button buttonName="Add resume" onClick={clickHandler} />
-            </div>
-          ) : (
-            <div className="add-btn">
-              <Button buttonName="Add resume" />
-            </div>
-          )}
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'row',
+              float: 'right',
+            }}
+          >
+            {error && (
+              <p style={{ color: 'red', marginRight: '50px' }}>{error}</p>
+            )}
+            {uploadedFile ? (
+              <div className="add-btn">
+                <Button buttonName="Add resume" onClick={clickHandler} />
+              </div>
+            ) : (
+              <div className="add-btn">
+                <Button buttonName="Add resume" />
+              </div>
+            )}
+          </div>
         </div>
       </div>
-    </div>)
-    : null,
+    ) : null,
     document.querySelector('#portal'),
   );
 };

--- a/src/client/components/MyProfile/ProfilePage/ProfileComponent.js
+++ b/src/client/components/MyProfile/ProfilePage/ProfileComponent.js
@@ -61,7 +61,7 @@ export default function ProfileComponent() {
           />
         </div>
         <div className="uploaded-cv">
-           <YourUploadedCVs CVsList={cvsList} />
+           <YourUploadedCVs CVsList={cvsList} setIsLoaded={setIsLoaded}/>
         </div>
         <div className="sent-reviews">
           <span>

--- a/src/client/components/MyProfile/YourUploadedCVs/YourUploadedCVs.js
+++ b/src/client/components/MyProfile/YourUploadedCVs/YourUploadedCVs.js
@@ -6,7 +6,7 @@ import Button from '../../Button/Button';
 import PropTypes from 'prop-types';
 import { AddResume } from '../../AddResume/AddResume';
 
-export function YourUploadedCVs({ CVsList}) {
+export function YourUploadedCVs({ CVsList, setIsLoaded }) {
   const [isShown, setIsShown] = useState(false);
 
   return (
@@ -18,10 +18,14 @@ export function YourUploadedCVs({ CVsList}) {
         <div className="upload-cv-botton">
           <Button
             buttonName="Upload new CV"
-            style={{ backgroundColor: 'black' }} 
-            onClick = {()=> setIsShown(true) }
+            style={{ backgroundColor: 'black' }}
+            onClick={() => setIsShown(true)}
           />
-          <AddResume isShown={isShown} setIsShown={setIsShown}/>
+          <AddResume
+            isShown={isShown}
+            setIsShown={setIsShown}
+            setIsLoaded={setIsLoaded}
+          />
         </div>
       </div>
       <ul>
@@ -61,4 +65,5 @@ const Cvs = PropTypes.shape({
 
 YourUploadedCVs.propTypes = {
   CVsList: PropTypes.arrayOf(Cvs).isRequired,
+  setIsLoaded: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
# Description
Right now when we add a resume, the onClick event can be invoked more than once so it end up adding more than one cv in the database, I addition, ideally the pop up menu(Addresume page)  should disappear after pressing the Add resume button.
this missed functionality has been added in this PR.
Please provide a short summary explaining what this PR is about.

Fixes # (issue)

# How to test?

Please provide a short summary how your changes can be tested?
# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] This PR is ready to be merged and not breaking any other functionality
