### PR TITLE
Fix clash of classes on the github logo...

### DIFF
--- a/src/client/components/LoginForm/LoginForm.css
+++ b/src/client/components/LoginForm/LoginForm.css
@@ -42,15 +42,6 @@ h3:after {
   left: 0.5em;
   margin-right: -50%;
 }
-.github-logo {
-  display: block;
-  border: 1px solid gray;
-  background-color: rgb(241, 241, 241);
-  width: 40px;
-  height: 40px;
-  padding: 10px;
-  margin-left: 15px;
-}
 
 .partition {
   color: lightgray;

--- a/src/client/components/LoginForm/LoginForm.js
+++ b/src/client/components/LoginForm/LoginForm.js
@@ -2,7 +2,7 @@ import React from 'react';
 import useForm from './useForm';
 import validate from './Validation';
 import './LoginForm.css';
-import github from './github.png';
+import iconGithub from '../../assets/images/icons/github.svg';
 import Button from '../Button/Button';
 
 function LoginForm({ onSubmit }) {
@@ -24,8 +24,8 @@ function LoginForm({ onSubmit }) {
             buttonName="Log in with Linkedin"
             style={{ backgroundColor: '#0388fc' }}
           />
-          <div className="github-logo">
-            <img src={github} alt="github-icon" />
+          <div className="github-container">
+            <img className="github-logo" src={iconGithub} alt="github icon" />
           </div>
         </div>
         <div className="partition">


### PR DESCRIPTION
... between the sign in and sign up page

# Description

Fix on overwritten classes between the sign in and sign up page
![Screenshot (2696)](https://user-images.githubusercontent.com/36211640/109730228-78283800-7bb9-11eb-8653-b4816817de50.png)

Fixes # (issue)

# How to test?

npm run dev.
The logo should look the same in both pages:

![Screenshot (2697)](https://user-images.githubusercontent.com/36211640/109730363-a9086d00-7bb9-11eb-9205-2eed34fd4c69.png)

![Screenshot (2698)](https://user-images.githubusercontent.com/36211640/109730359-a9086d00-7bb9-11eb-9dd1-241727aa0f36.png)

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] This PR is ready to be merged and not breaking any other functionality
